### PR TITLE
Configure Maven and Spring properties for Azure SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ https://youtu.be/vhddup5DgIQ
 
 - **Linguagem**: Java 17.
 - **Frameworks principais**: Spring Boot (Web, Data JPA, Security), Thymeleaf, Flyway e Lombok. 【F:pom.xml†L24-L79】
-- **Banco de dados**: Oracle, com versionamento de esquema e dados usando Flyway. 【F:src/main/resources/db/migration/V1__baseline.sql†L1-L43】【F:src/main/resources/db/migration/V2__seed_usuarios.sql†L1-L2】【F:src/main/resources/db/migration/V3__seed_vagas.sql†L1-L3】
+- **Banco de dados**: Azure SQL Database (SQL Server), com versionamento de esquema e dados usando Flyway. 【F:src/main/resources/db/migration/V1__baseline.sql†L1-L43】【F:src/main/resources/db/migration/V2__seed_usuarios.sql†L1-L2】【F:src/main/resources/db/migration/V3__seed_vagas.sql†L1-L3】
 - **Front-end**: páginas Thymeleaf servidas pelo Spring MVC com assets estáticos em `/static`.
 
 ## Pré-requisitos
 
 1. **Java 17** (JDK) instalado e configurado no `PATH`.
 2. **Maven 3.9+** ou uso do wrapper (`mvnw`).
-3. **Banco Oracle** acessível. Ajuste a URL, usuário e senha conforme seu ambiente em `src/main/resources/application.properties`. 【F:src/main/resources/application.properties†L1-L19】
-4. Usuário com privilégios suficientes para executar as migrações Flyway no schema informado.
+3. **Azure SQL Database** acessível (porta 1433 liberada). Configure a URL JDBC, usuário e senha via variáveis de ambiente `AZURE_SQL_URL`, `AZURE_SQL_USER` e `AZURE_SQL_PASSWORD`. 【F:src/main/resources/application.properties†L1-L21】
+4. Usuário com privilégios suficientes para executar as migrações Flyway no schema configurado (`AZURE_SQL_SCHEMA`, padrão `dbo`). 【F:src/main/resources/application.properties†L9-L17】
 
 ## Configuração do banco e dados iniciais
 
-1. Atualize `src/main/resources/application.properties` com as credenciais e schema do seu banco Oracle.
+1. Defina as variáveis de ambiente com as credenciais do Azure SQL antes de iniciar a aplicação ou executar o Flyway.
 2. Atualize o seed do gerente em `V2__seed_usuarios.sql` com um hash BCrypt real antes de executar as migrações. Você pode gerar um hash executando `new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder().encode("suaSenha")` em um REPL Spring ou pequena classe utilitária. 【F:src/main/resources/db/migration/V2__seed_usuarios.sql†L1-L2】
 3. Execute as migrações:
    ```bash
@@ -55,6 +55,33 @@ https://youtu.be/vhddup5DgIQ
    ./mvnw spring-boot:run
    ```
 3. A aplicação será iniciada em `http://localhost:8080/` por padrão.
+
+### Variáveis de ambiente locais
+
+Exemplo de configuração em sistemas Unix-like:
+
+```bash
+export AZURE_SQL_URL="jdbc:sqlserver://<servidor>.database.windows.net:1433;database=<nome>;encrypt=true;trustServerCertificate=false;loginTimeout=30"
+export AZURE_SQL_USER="<usuario>"
+export AZURE_SQL_PASSWORD="<senha>"
+export AZURE_SQL_SCHEMA="dbo" # opcional; use se estiver trabalhando com outro schema
+```
+
+No Windows (PowerShell):
+
+```powershell
+$Env:AZURE_SQL_URL = "jdbc:sqlserver://<servidor>.database.windows.net:1433;database=<nome>;encrypt=true;trustServerCertificate=false;loginTimeout=30"
+$Env:AZURE_SQL_USER = "<usuario>"
+$Env:AZURE_SQL_PASSWORD = "<senha>"
+$Env:AZURE_SQL_SCHEMA = "dbo" # opcional
+```
+
+### Configurando no Azure App Service
+
+1. Acesse o portal do Azure e abra o App Service da aplicação.
+2. Em **Configurações** > **Variáveis de Aplicativo**, adicione as chaves `AZURE_SQL_URL`, `AZURE_SQL_USER`, `AZURE_SQL_PASSWORD` e, se necessário, `AZURE_SQL_SCHEMA`.
+3. O valor de `AZURE_SQL_URL` deve seguir o formato `jdbc:sqlserver://<servidor>.database.windows.net:1433;database=<nome>;encrypt=true;trustServerCertificate=false;loginTimeout=30`.
+4. Salve as alterações e reinicie o App Service para aplicar as novas configurações.
 
 ## Fluxo de acesso e credenciais
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,9 @@
     <properties>
         <java.version>17</java.version>
         <flyway.version>11.13.1</flyway.version>
+        <azure.sql.url>${env.AZURE_SQL_URL}</azure.sql.url>
+        <azure.sql.user>${env.AZURE_SQL_USER}</azure.sql.user>
+        <azure.sql.password>${env.AZURE_SQL_PASSWORD}</azure.sql.password>
     </properties>
 
     <dependencies>
@@ -35,11 +38,6 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>12.6.1.jre11</version>
-        </dependency>
-        <dependency>
-        <groupId>com.microsoft.sqlserver</groupId>
-        <artifactId>mssql-jdbc</artifactId>
-        <version>12.6.1.jre11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -61,21 +59,10 @@
             <artifactId>spring-boot-starter-data-jdbc</artifactId>
         </dependency>
 
-        <!-- Oracle JDBC (ok no Java 17) -->
-        <dependency>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>21.9.0.0</version>
-        </dependency>
         <!-- Flyway -->
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>${flyway.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-database-oracle</artifactId>
             <version>${flyway.version}</version>
         </dependency>
 
@@ -126,10 +113,9 @@
                 <artifactId>flyway-maven-plugin</artifactId>
                 <version>${flyway.version}</version>
                 <configuration>
-                    <url>jdbc:oracle:thin:@oracle.fiap.com.br:1521/ORCL</url>
-                    <user>rm554983</user>
-                    <password>191205</password>
-                    <schemas>RM554983</schemas>
+                    <url>${azure.sql.url}</url>
+                    <user>${azure.sql.user}</user>
+                    <password>${azure.sql.password}</password>
                     <locations>
                         <location>classpath:db/migration</location>
                     </locations>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,18 @@
 spring.application.name=nextpark
-spring.datasource.url=jdbc:oracle:thin:@oracle.fiap.com.br:1521:ORCL
-spring.datasource.username=RM554983
-spring.datasource.password=191205
+spring.datasource.url=${AZURE_SQL_URL}
+spring.datasource.username=${AZURE_SQL_USER}
+spring.datasource.password=${AZURE_SQL_PASSWORD}
 
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 
-
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 spring.flyway.baseline-on-migrate=true
-spring.flyway.schemas=RM554983
+spring.flyway.url=${AZURE_SQL_URL}
+spring.flyway.user=${AZURE_SQL_USER}
+spring.flyway.password=${AZURE_SQL_PASSWORD}
+spring.flyway.schemas=${AZURE_SQL_SCHEMA:dbo}
 spring.flyway.clean-disabled=false
 spring.flyway.baseline-version=0
 


### PR DESCRIPTION
## Summary
- remove Oracle-specific dependencies, deduplicate the SQL Server driver, and configure the Flyway plugin to read Azure SQL settings from environment variables
- externalize Spring datasource and Flyway credentials to Azure SQL environment variables and document the new setup steps in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd80eabf6883288bb37077d3b48584